### PR TITLE
feat: ajout endpoint de consultation du catalogue de cartes

### DIFF
--- a/bruno/Auth/folder.bru
+++ b/bruno/Auth/folder.bru
@@ -1,21 +1,21 @@
 meta {
   name: Auth
-  seq: 3
+  seq: 2
 }
 
 docs {
   # Authentification
-
+  
   Endpoints pour l'inscription et la connexion des utilisateurs.
-
+  
   ## Endpoints disponibles
   - **Sign In (Red)** : Se connecter avec l'utilisateur Red
   - **Sign In (Blue)** : Se connecter avec l'utilisateur Blue
   - **Sign Up** : Créer un nouveau compte
-
+  
   ## Utilisateurs de test
   - **Red** : red@example.com / password123
   - **Blue** : blue@example.com / password123
-
+  
   📖 Voir le README de ce dossier pour plus de détails.
 }

--- a/bruno/Cards/Get All Cards.bru
+++ b/bruno/Cards/Get All Cards.bru
@@ -14,11 +14,15 @@ auth:bearer {
   token: {{token}}
 }
 
+vars:pre-request {
+  baseUrl: http://localhost:3001
+}
+
 docs {
   Get all available cards in the game.
-
+  
   Requires authentication.
-
+  
   Returns:
   - 200: List of all cards
   - 401: Unauthorized (missing or invalid token)

--- a/bruno/Cards/folder.bru
+++ b/bruno/Cards/folder.bru
@@ -1,20 +1,20 @@
 meta {
   name: Cards
-  seq: 4
+  seq: 3
 }
 
 docs {
   # Cartes
-
+  
   Endpoints pour récupérer les cartes Pokemon disponibles dans le jeu.
-
+  
   ## Endpoints disponibles
   - **Get All Cards** : Récupérer toutes les cartes (authentification requise)
-
+  
   ## Informations
   - Les cartes sont chargées depuis `prisma/data/pokemon.json` lors du seed
   - Chaque carte contient : id, name, hp, attack, type, pokedexNumber, imgUrl
   - Les cartes sont triées par numéro Pokédex
-
+  
   📖 Voir le README de ce dossier pour plus de détails.
 }

--- a/bruno/Decks/folder.bru
+++ b/bruno/Decks/folder.bru
@@ -1,25 +1,25 @@
 meta {
   name: Decks
-  seq: 5
+  seq: 4
 }
 
 docs {
   # Decks
-
+  
   Endpoints CRUD pour gérer les decks de cartes.
-
+  
   ## Règle importante
   Un deck doit contenir **exactement 10 cartes valides**.
-
+  
   ## Endpoints disponibles
   - **Create Deck** : Créer un nouveau deck
   - **Get My Decks** : Récupérer tous ses decks
   - **Get Deck by ID** : Récupérer un deck spécifique
   - **Update Deck** : Modifier le nom et/ou les cartes d'un deck
   - **Delete Deck** : Supprimer un deck
-
+  
   ## Variables automatiques
   Après "Get My Decks", la variable `{{deckId}}` est automatiquement remplie avec l'ID du premier deck pour faciliter les tests.
-
+  
   📖 Voir le README de ce dossier pour plus de détails.
 }

--- a/bruno/Health Check.bru
+++ b/bruno/Health Check.bru
@@ -1,7 +1,7 @@
 meta {
   name: Health Check
   type: http
-  seq: 2
+  seq: 1
 }
 
 get {

--- a/src/cards/route/cards.route.ts
+++ b/src/cards/route/cards.route.ts
@@ -1,0 +1,16 @@
+import { Router } from "express";
+import { prisma } from "../../database"; 
+
+export const cardsRouter = Router();
+
+cardsRouter.get("/", async (_req, res) => {
+  try {
+    const cards = await prisma.card.findMany({
+      orderBy: { pokedexNumber: "asc" },
+    });
+
+    return res.status(200).json(cards);
+  } catch (error) {
+    return res.status(500).json({ error: "Erreur serveur" });
+  }
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import cors from "cors";
 import 'dotenv/config'
 import { authRouter } from "./auth/route/auth.route";
 import { authenticateToken } from "./auth/middleware/auth.middleware";
+import { cardsRouter } from "./cards/route/cards.route";
+
 
 
 // Create Express app
@@ -23,6 +25,7 @@ app.use("/api/auth", authRouter);
 app.get("/api/decks", authenticateToken, (req, res) => {
   return res.status(200).json({ message: "OK", user: req.user });
 });
+app.use("/api/cards", cardsRouter);
 
 
 // Serve static files (Socket.io test client)


### PR DESCRIPTION
Closes #4 

Ajout de l’endpoint public GET /api/cards pour récupérer la liste complète des cartes Pokémon, triées par numéro de Pokédex.

Pour tester, il faut lancer le serveur puis appeler GET /api/cards avec Bruno (dans lz méthode "Get All Cards").