### PR TITLE
6 tests unitaires

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "start": "prisma migrate deploy && node dist/index.js",
     "test": "vitest --coverage --run",
     "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage --run",
     "db:start": "docker compose up -d",
     "db:stop": "docker compose down",
     "db:generate": "prisma generate",

--- a/src/decks/controller/deck.controller.ts
+++ b/src/decks/controller/deck.controller.ts
@@ -5,7 +5,7 @@ export const deckController = {
   async create(req: Request, res: Response) {
     try {
       const userId = req.user!.userId
-      const { name, cards } = req.body ?? {}
+      const { name, cards } = req.body
 
       const result = await deckService.createDeck(userId, name, cards)
       if (!result.ok)
@@ -43,7 +43,7 @@ export const deckController = {
   async update(req: Request, res: Response) {
     try {
       const userId = req.user!.userId
-      const { name, cards } = req.body ?? {}
+      const { name, cards } = req.body
 
       const result = await deckService.update(
         userId,

--- a/tests/auth.middleware.test.ts
+++ b/tests/auth.middleware.test.ts
@@ -1,0 +1,140 @@
+import { describe, it, expect, vi, beforeAll } from "vitest";
+import jwt from "jsonwebtoken";
+import { authenticateToken } from "../src/auth/middleware/auth.middleware";
+import type { Request, Response } from "express";
+
+type AuthenticatedRequest = Request & {
+  user?: { userId: number; email: string };
+};
+
+const JWT_SECRET = "test-secret";
+
+beforeAll(() => {
+  process.env.JWT_SECRET = JWT_SECRET;
+});
+
+const mockReq = (overrides: Partial<AuthenticatedRequest> = {}): AuthenticatedRequest =>
+  ({
+    headers: {},
+    ...overrides,
+  } as AuthenticatedRequest);
+
+const mockRes = () => {
+  const res = {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+  return res;
+};
+
+describe("authenticateToken middleware", () => {
+  it("401 → pas d'en-tête Authorization", () => {
+    const req = mockReq({ headers: {} });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token manquant" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 → Authorization present mais ne commence pas par 'Bearer '", () => {
+    const req = mockReq({
+      headers: { authorization: "Basic abc123" },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token manquant" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 → 'Bearer ' sans token apres (chaine vide apres split)", () => {
+    const req = mockReq({
+      headers: { authorization: "Bearer " },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token manquant" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 → token invalide / malformate", () => {
+    const req = mockReq({
+      headers: { authorization: "Bearer invalid.token.here" },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token invalide ou expiré" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 → token signe avec un mauvais secret", () => {
+    const badToken = jwt.sign({ userId: 1, email: "x@y.com" }, "wrong-secret");
+    const req = mockReq({
+      headers: { authorization: `Bearer ${badToken}` },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token invalide ou expiré" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("401 → token expire", () => {
+    const expiredToken = jwt.sign(
+      { userId: 1, email: "red@tcg.com" },
+      JWT_SECRET,
+      { expiresIn: -1 },
+    );
+    const req = mockReq({
+      headers: { authorization: `Bearer ${expiredToken}` },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(res.json).toHaveBeenCalledWith({ error: "Token invalide ou expiré" });
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("appelle next() et attache req.user si token valide", () => {
+    const validToken = jwt.sign(
+      { userId: 42, email: "red@tcg.com" },
+      JWT_SECRET,
+      { expiresIn: "7d" },
+    );
+    const req = mockReq({
+      headers: { authorization: `Bearer ${validToken}` },
+    });
+    const res = mockRes();
+    const next = vi.fn();
+
+    authenticateToken(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(req.user).toMatchObject({
+      userId: 42,
+      email: "red@tcg.com",
+    });
+    expect(res.status).not.toHaveBeenCalled();
+  });
+});

--- a/tests/auth.middleware.test.ts
+++ b/tests/auth.middleware.test.ts
@@ -28,7 +28,7 @@ const mockRes = () => {
 };
 
 describe("authenticateToken middleware", () => {
-  it("401 → pas d'en-tête Authorization", () => {
+  it("401 : pas d'en-tête Authorization", () => {
     const req = mockReq({ headers: {} });
     const res = mockRes();
     const next = vi.fn();
@@ -40,7 +40,7 @@ describe("authenticateToken middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("401 → Authorization present mais ne commence pas par 'Bearer '", () => {
+  it("401 : Authorization present mais ne commence pas par 'Bearer '", () => {
     const req = mockReq({
       headers: { authorization: "Basic abc123" },
     });
@@ -54,7 +54,7 @@ describe("authenticateToken middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("401 → 'Bearer ' sans token apres (chaine vide apres split)", () => {
+  it("401 : 'Bearer ' sans token", () => {
     const req = mockReq({
       headers: { authorization: "Bearer " },
     });
@@ -68,7 +68,7 @@ describe("authenticateToken middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("401 → token invalide / malformate", () => {
+  it("401 : token invalide ", () => {
     const req = mockReq({
       headers: { authorization: "Bearer invalid.token.here" },
     });
@@ -82,7 +82,7 @@ describe("authenticateToken middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("401 → token signe avec un mauvais secret", () => {
+  it("401 : token signe avec un mauvais secret", () => {
     const badToken = jwt.sign({ userId: 1, email: "x@y.com" }, "wrong-secret");
     const req = mockReq({
       headers: { authorization: `Bearer ${badToken}` },
@@ -97,7 +97,7 @@ describe("authenticateToken middleware", () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it("401 → token expire", () => {
+  it("401 : token expire", () => {
     const expiredToken = jwt.sign(
       { userId: 1, email: "red@tcg.com" },
       JWT_SECRET,

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -21,7 +21,7 @@ describe("POST /api/auth/sign-up", () => {
     prismaMock.user.create.mockReset();
   });
 
-  it("201 → inscription réussie avec des données valides", async () => {
+  it("201 : inscription réussie avec des données valides", async () => {
     prismaMock.user.findUnique.mockResolvedValue(null);
     prismaMock.user.create.mockResolvedValue(
       makeUser({ id: 1, email: "red@tcg.com", username: "Red" }),
@@ -38,7 +38,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.user).toMatchObject({ email: "red@tcg.com", name: "Red" });
   });
 
-  it("400 → email manquant", async () => {
+  it("400 : email manquant", async () => {
     const res = await request(app).post("/api/auth/sign-up").send({
       username: "Red",
       password: "password123",
@@ -47,7 +47,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Champs manquants");
   });
 
-  it("400 → username manquant", async () => {
+  it("400 : username manquant", async () => {
     const res = await request(app).post("/api/auth/sign-up").send({
       email: "red@tcg.com",
       password: "password123",
@@ -56,7 +56,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Champs manquants");
   });
 
-  it("400 → password manquant", async () => {
+  it("400 : password manquant", async () => {
     const res = await request(app).post("/api/auth/sign-up").send({
       email: "red@tcg.com",
       username: "Red",
@@ -65,7 +65,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Champs manquants");
   });
 
-  it("400 → email non-string (données invalides)", async () => {
+  it("400 : email non-string (données invalides)", async () => {
     const res = await request(app).post("/api/auth/sign-up").send({
       email: 123,
       username: "Red",
@@ -75,7 +75,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Données invalides");
   });
 
-  it("400 → username non-string (données invalides)", async () => {
+  it("400 : username non-string", async () => {
     const res = await request(app).post("/api/auth/sign-up").send({
       email: "red@tcg.com",
       username: 42,
@@ -85,7 +85,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Données invalides");
   });
 
-  it("400 → password non-string (données invalides)", async () => {
+  it("400 : password non-string", async () => {
     const res = await request(app).post("/api/auth/sign-up").send({
       email: "red@tcg.com",
       username: "Red",
@@ -95,7 +95,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Données invalides");
   });
 
-  it("409 → email déjà utilisé", async () => {
+  it("409 : email déjà utilisé", async () => {
     prismaMock.user.findUnique.mockResolvedValue(makeUser());
 
     const res = await request(app).post("/api/auth/sign-up").send({
@@ -108,7 +108,7 @@ describe("POST /api/auth/sign-up", () => {
     expect(res.body.error).toBe("Email déjà utilisé");
   });
 
-  it("500 → erreur serveur (prisma lève une erreur)", async () => {
+  it("500 : erreur serveur", async () => {
     prismaMock.user.findUnique.mockRejectedValue(new Error("DB down"));
 
     const res = await request(app).post("/api/auth/sign-up").send({
@@ -127,7 +127,7 @@ describe("POST /api/auth/sign-in", () => {
     prismaMock.user.findUnique.mockReset();
   });
 
-  it("200 → connexion réussie avec bonnes credentials", async () => {
+  it("200 : connexion réussie", async () => {
     const hashed = await bcrypt.hash("password123", 10);
     prismaMock.user.findUnique.mockResolvedValue(makeUser({ password: hashed }));
 
@@ -142,7 +142,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.user).toMatchObject({ email: "red@tcg.com" });
   });
 
-  it("400 → email manquant", async () => {
+  it("400 : email manquant", async () => {
     const res = await request(app).post("/api/auth/sign-in").send({
       password: "password123",
     });
@@ -150,7 +150,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.error).toBe("Champs manquants");
   });
 
-  it("400 → password manquant", async () => {
+  it("400 : password manquant", async () => {
     const res = await request(app).post("/api/auth/sign-in").send({
       email: "red@tcg.com",
     });
@@ -158,7 +158,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.error).toBe("Champs manquants");
   });
 
-  it("400 → email non-string (données invalides)", async () => {
+  it("400 : email non-string", async () => {
     const res = await request(app).post("/api/auth/sign-in").send({
       email: 42,
       password: "password123",
@@ -167,7 +167,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.error).toBe("Données invalides");
   });
 
-  it("400 → password non-string (données invalides)", async () => {
+  it("400 : password non-string", async () => {
     const res = await request(app).post("/api/auth/sign-in").send({
       email: "red@tcg.com",
       password: false,
@@ -176,7 +176,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.error).toBe("Champs manquants");
   });
 
-  it("401 → utilisateur introuvable", async () => {
+  it("401 : utilisateur introuvable", async () => {
     prismaMock.user.findUnique.mockResolvedValue(null);
 
     const res = await request(app).post("/api/auth/sign-in").send({
@@ -188,7 +188,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.error).toBe("Email ou mot de passe incorrect");
   });
 
-  it("401 → mauvais mot de passe", async () => {
+  it("401 : mauvais mot de passe", async () => {
     const hashed = await bcrypt.hash("correct-password", 10);
     prismaMock.user.findUnique.mockResolvedValue(makeUser({ password: hashed }));
 
@@ -201,7 +201,7 @@ describe("POST /api/auth/sign-in", () => {
     expect(res.body.error).toBe("Email ou mot de passe incorrect");
   });
 
-  it("500 → erreur serveur (prisma lève une erreur)", async () => {
+  it("500 : erreur serveur", async () => {
     prismaMock.user.findUnique.mockRejectedValue(new Error("DB down"));
 
     const res = await request(app).post("/api/auth/sign-in").send({

--- a/tests/auth.test.ts
+++ b/tests/auth.test.ts
@@ -1,0 +1,215 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import request from "supertest";
+import bcrypt from "bcrypt";
+import { app } from "../src/index";
+import { prismaMock } from "./vitest.setup";
+import type { User } from "../src/generated/prisma/client";
+
+const makeUser = (overrides: Partial<User> = {}): User => ({
+  id: 1,
+  email: "red@tcg.com",
+  username: "Red",
+  password: "$2b$10$hashedpassword",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  ...overrides,
+});
+
+describe("POST /api/auth/sign-up", () => {
+  beforeEach(() => {
+    prismaMock.user.findUnique.mockReset();
+    prismaMock.user.create.mockReset();
+  });
+
+  it("201 → inscription réussie avec des données valides", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+    prismaMock.user.create.mockResolvedValue(
+      makeUser({ id: 1, email: "red@tcg.com", username: "Red" }),
+    );
+
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      username: "Red",
+      password: "password123",
+    });
+
+    expect(res.status).toBe(201);
+    expect(res.body).toHaveProperty("token");
+    expect(res.body.user).toMatchObject({ email: "red@tcg.com", name: "Red" });
+  });
+
+  it("400 → email manquant", async () => {
+    const res = await request(app).post("/api/auth/sign-up").send({
+      username: "Red",
+      password: "password123",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Champs manquants");
+  });
+
+  it("400 → username manquant", async () => {
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      password: "password123",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Champs manquants");
+  });
+
+  it("400 → password manquant", async () => {
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      username: "Red",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Champs manquants");
+  });
+
+  it("400 → email non-string (données invalides)", async () => {
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: 123,
+      username: "Red",
+      password: "password123",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Données invalides");
+  });
+
+  it("400 → username non-string (données invalides)", async () => {
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      username: 42,
+      password: "password123",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Données invalides");
+  });
+
+  it("400 → password non-string (données invalides)", async () => {
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      username: "Red",
+      password: true,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Données invalides");
+  });
+
+  it("409 → email déjà utilisé", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(makeUser());
+
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      username: "Red",
+      password: "password123",
+    });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toBe("Email déjà utilisé");
+  });
+
+  it("500 → erreur serveur (prisma lève une erreur)", async () => {
+    prismaMock.user.findUnique.mockRejectedValue(new Error("DB down"));
+
+    const res = await request(app).post("/api/auth/sign-up").send({
+      email: "red@tcg.com",
+      username: "Red",
+      password: "password123",
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("Erreur serveur");
+  });
+});
+
+describe("POST /api/auth/sign-in", () => {
+  beforeEach(() => {
+    prismaMock.user.findUnique.mockReset();
+  });
+
+  it("200 → connexion réussie avec bonnes credentials", async () => {
+    const hashed = await bcrypt.hash("password123", 10);
+    prismaMock.user.findUnique.mockResolvedValue(makeUser({ password: hashed }));
+
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: "red@tcg.com",
+      password: "password123",
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty("token");
+    expect(res.body.message).toBe("Connexion réussie");
+    expect(res.body.user).toMatchObject({ email: "red@tcg.com" });
+  });
+
+  it("400 → email manquant", async () => {
+    const res = await request(app).post("/api/auth/sign-in").send({
+      password: "password123",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Champs manquants");
+  });
+
+  it("400 → password manquant", async () => {
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: "red@tcg.com",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Champs manquants");
+  });
+
+  it("400 → email non-string (données invalides)", async () => {
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: 42,
+      password: "password123",
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Données invalides");
+  });
+
+  it("400 → password non-string (données invalides)", async () => {
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: "red@tcg.com",
+      password: false,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("Champs manquants");
+  });
+
+  it("401 → utilisateur introuvable", async () => {
+    prismaMock.user.findUnique.mockResolvedValue(null);
+
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: "unknown@tcg.com",
+      password: "password123",
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Email ou mot de passe incorrect");
+  });
+
+  it("401 → mauvais mot de passe", async () => {
+    const hashed = await bcrypt.hash("correct-password", 10);
+    prismaMock.user.findUnique.mockResolvedValue(makeUser({ password: hashed }));
+
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: "red@tcg.com",
+      password: "wrong-password",
+    });
+
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Email ou mot de passe incorrect");
+  });
+
+  it("500 → erreur serveur (prisma lève une erreur)", async () => {
+    prismaMock.user.findUnique.mockRejectedValue(new Error("DB down"));
+
+    const res = await request(app).post("/api/auth/sign-in").send({
+      email: "red@tcg.com",
+      password: "password123",
+    });
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("Erreur serveur");
+  });
+});

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -21,7 +21,7 @@ describe("GET /api/cards", () => {
     prismaMock.card.findMany.mockReset();
   });
 
-  it("200 → retourne la liste de toutes les cartes", async () => {
+  it("200 : retourne la liste de toutes les cartes", async () => {
     const cards = [makeCard(1), makeCard(2), makeCard(3)];
     prismaMock.card.findMany.mockResolvedValue(cards);
 
@@ -32,7 +32,7 @@ describe("GET /api/cards", () => {
     expect(res.body[0]).toMatchObject({ id: 1, name: "Card 1" });
   });
 
-  it("200 → retourne un tableau vide si aucune carte", async () => {
+  it("200 : retourne un tableau vide si aucune carte", async () => {
     prismaMock.card.findMany.mockResolvedValue([]);
 
     const res = await request(app).get("/api/cards");
@@ -41,7 +41,7 @@ describe("GET /api/cards", () => {
     expect(res.body).toEqual([]);
   });
 
-  it("200 → les cartes sont triées par pokedexNumber (asc)", async () => {
+  it("200 : les cartes sont triées par pokedexNumber", async () => {
     const cards = [makeCard(1), makeCard(2), makeCard(3)];
     prismaMock.card.findMany.mockResolvedValue(cards);
 
@@ -52,7 +52,7 @@ describe("GET /api/cards", () => {
     });
   });
 
-  it("500 → erreur serveur si prisma lève une erreur", async () => {
+  it("500 : erreur serveur si prisma lève une erreur", async () => {
     prismaMock.card.findMany.mockRejectedValue(new Error("DB down"));
 
     const res = await request(app).get("/api/cards");

--- a/tests/card.test.ts
+++ b/tests/card.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import request from "supertest";
+import { app } from "../src/index";
+import { prismaMock } from "./vitest.setup";
+import { PokemonType } from "../src/generated/prisma/client";
+
+const makeCard = (id: number) => ({
+  id,
+  name: `Card ${id}`,
+  pokedexNumber: id,
+  hp: 45,
+  attack: 49,
+  type: PokemonType.Grass,
+  imgUrl: "https://example.com/card.png",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+describe("GET /api/cards", () => {
+  beforeEach(() => {
+    prismaMock.card.findMany.mockReset();
+  });
+
+  it("200 → retourne la liste de toutes les cartes", async () => {
+    const cards = [makeCard(1), makeCard(2), makeCard(3)];
+    prismaMock.card.findMany.mockResolvedValue(cards);
+
+    const res = await request(app).get("/api/cards");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(3);
+    expect(res.body[0]).toMatchObject({ id: 1, name: "Card 1" });
+  });
+
+  it("200 → retourne un tableau vide si aucune carte", async () => {
+    prismaMock.card.findMany.mockResolvedValue([]);
+
+    const res = await request(app).get("/api/cards");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("200 → les cartes sont triées par pokedexNumber (asc)", async () => {
+    const cards = [makeCard(1), makeCard(2), makeCard(3)];
+    prismaMock.card.findMany.mockResolvedValue(cards);
+
+    await request(app).get("/api/cards");
+
+    expect(prismaMock.card.findMany).toHaveBeenCalledWith({
+      orderBy: { pokedexNumber: "asc" },
+    });
+  });
+
+  it("500 → erreur serveur si prisma lève une erreur", async () => {
+    prismaMock.card.findMany.mockRejectedValue(new Error("DB down"));
+
+    const res = await request(app).get("/api/cards");
+
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe("Erreur serveur");
+  });
+});

--- a/tests/deck.coverage.test.ts
+++ b/tests/deck.coverage.test.ts
@@ -1,17 +1,6 @@
 /**
- * deck_coverage.test.ts
- *
- * Complementary tests targeting the lines NOT covered by deck.test.ts:
- *
- * deck.repository.ts
- *   • lines  5-10  → deckRepository.createDeck
- *   • lines 12-16  → deckRepository.addDeckCards
- *   • lines 40-43  → deckRepository.updateDeckName
- *   • lines 45-47  → deckRepository.deleteDeck
- *
- * deck.controller.ts
- *   • line   8     → `const { name, cards } = req.body ?? {}`  (body absent)
- *   • line  46     → `const { name, cards } = req.body ?? {}`  (body absent, PATCH)
+ * deck_coverage.test.ts : Test complementaire pour 
+ * s'occuper des lignes qui ne peucent pas être couvertes par deck.test.ts:
  */
 
 import { describe, it, expect, beforeAll, beforeEach } from "vitest";
@@ -21,8 +10,6 @@ import { app } from "../src/index";
 import { prismaMock } from "./vitest.setup";
 import { PokemonType } from "../src/generated/prisma/client";
 import { deckRepository } from "../src/decks/repository/deck.repository";
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
 
 const makeToken = (payload: { userId: number; email: string }) => {
   const secret = process.env.JWT_SECRET;
@@ -66,9 +53,6 @@ const makeDeckWithCards = (
   })),
 });
 
-
-// ─── Repository unit tests ────────────────────────────────────────────────────
-
 describe("deckRepository — fonctions non couvertes", () => {
   beforeAll(() => {
     process.env.JWT_SECRET = "test-secret";
@@ -82,8 +66,7 @@ describe("deckRepository — fonctions non couvertes", () => {
     prismaMock.deckCard.deleteMany.mockReset();
   });
 
-  // lines 5-10 — createDeck
-  it("createDeck → appelle prisma.deck.create avec userId et name", async () => {
+  it("createDeck : appelle prisma.deck.create avec userId et name", async () => {
     const expected = makeDeck(1, 42);
     prismaMock.deck.create.mockResolvedValue(expected);
 
@@ -95,8 +78,7 @@ describe("deckRepository — fonctions non couvertes", () => {
     expect(result).toEqual(expected);
   });
 
-  // lines 12-16 — addDeckCards
-  it("addDeckCards → appelle prisma.deckCard.createMany avec les bons deckCard", async () => {
+  it("addDeckCards : appelle prisma.deckCard.createMany avec les bons deckCard", async () => {
     prismaMock.deckCard.createMany.mockResolvedValue({ count: 3 });
 
     const result = await deckRepository.addDeckCards(5, [10, 20, 30]);
@@ -111,8 +93,7 @@ describe("deckRepository — fonctions non couvertes", () => {
     expect(result).toEqual({ count: 3 });
   });
 
-  // line 17 — deleteDeckCards
-  it("deleteDeckCards → appelle prisma.deckCard.deleteMany avec le bon deckId", async () => {
+  it("deleteDeckCards : appelle prisma.deckCard.deleteMany avec le bon deckId", async () => {
     prismaMock.deckCard.deleteMany.mockResolvedValue({ count: 10 });
 
     const result = await deckRepository.deleteDeckCards(5);
@@ -123,8 +104,7 @@ describe("deckRepository — fonctions non couvertes", () => {
     expect(result).toEqual({ count: 10 });
   });
 
-  // lines 40-43 — updateDeckName
-  it("updateDeckName → appelle prisma.deck.update avec le bon id et name", async () => {
+  it("updateDeckName : appelle prisma.deck.update avec le bon id et name", async () => {
     const updated = makeDeck(7, 1);
     prismaMock.deck.update.mockResolvedValue(updated);
 
@@ -137,8 +117,7 @@ describe("deckRepository — fonctions non couvertes", () => {
     expect(result).toEqual(updated);
   });
 
-  // lines 45-47 — deleteDeck
-  it("deleteDeck → appelle prisma.deck.delete avec le bon id", async () => {
+  it("deleteDeck : appelle prisma.deck.delete avec le bon id", async () => {
     const deleted = makeDeck(7, 1);
     prismaMock.deck.delete.mockResolvedValue(deleted);
 
@@ -148,8 +127,6 @@ describe("deckRepository — fonctions non couvertes", () => {
     expect(result).toEqual(deleted);
   });
 });
-
-// ─── Controller — req.body fallback (lines 8 & 46) ───────────────────────────
 
 describe("deckController — req.body absent (fallback ?? {})", () => {
   beforeAll(() => {
@@ -162,15 +139,9 @@ describe("deckController — req.body absent (fallback ?? {})", () => {
     prismaMock.card.findMany.mockReset();
   });
 
-  /**
-   * POST /api/decks sans body → le contrôleur fait `req.body ?? {}`
-   * puis le service valide et renvoie 400 (name manquant).
-   * L'important est que la ligne 8 du controller soit exécutée sans crash.
-   */
-  it("POST /api/decks sans body → 400 (name manquant, line 8 couverte)", async () => {
+  it("POST /api/decks sans body : 400 (ligne 8 couverte)", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
 
-    // Envoyer une requête sans .send() pour que req.body soit vide/undefined
     const res = await request(app)
       .post("/api/decks")
       .set("Authorization", `Bearer ${token}`)
@@ -179,12 +150,8 @@ describe("deckController — req.body absent (fallback ?? {})", () => {
     expect(res.status).toBe(400);
   });
 
-  /**
-   * PATCH /api/decks/:id sans body → le contrôleur fait `req.body ?? {}`
-   * puis le service valide et renvoie 400 (aucune donnée).
-   * L'important est que la ligne 46 du controller soit exécutée.
-   */
-  it("PATCH /api/decks/:id sans body → 400 (aucune donnée, line 46 couverte)", async () => {
+  
+  it("PATCH /api/decks/:id sans body : 400 (aucune donnée, line 46 couverte)", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),

--- a/tests/deck.coverage.test.ts
+++ b/tests/deck.coverage.test.ts
@@ -1,0 +1,200 @@
+/**
+ * deck_coverage.test.ts
+ *
+ * Complementary tests targeting the lines NOT covered by deck.test.ts:
+ *
+ * deck.repository.ts
+ *   • lines  5-10  → deckRepository.createDeck
+ *   • lines 12-16  → deckRepository.addDeckCards
+ *   • lines 40-43  → deckRepository.updateDeckName
+ *   • lines 45-47  → deckRepository.deleteDeck
+ *
+ * deck.controller.ts
+ *   • line   8     → `const { name, cards } = req.body ?? {}`  (body absent)
+ *   • line  46     → `const { name, cards } = req.body ?? {}`  (body absent, PATCH)
+ */
+
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { app } from "../src/index";
+import { prismaMock } from "./vitest.setup";
+import { PokemonType } from "../src/generated/prisma/client";
+import { deckRepository } from "../src/decks/repository/deck.repository";
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const makeToken = (payload: { userId: number; email: string }) => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET manquant dans les tests");
+  return jwt.sign(payload, secret, { expiresIn: "7d" });
+};
+
+const makeCard = (id: number) => ({
+  id,
+  name: `Card ${id}`,
+  pokedexNumber: id,
+  hp: 10,
+  attack: 10,
+  type: PokemonType.Grass,
+  imgUrl: "",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const makeDeck = (deckId: number, userId: number) => ({
+  id: deckId,
+  name: "My Deck",
+  userId,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const makeDeckWithCards = (
+  deckId: number,
+  userId: number,
+  cardIds: number[],
+) => ({
+  ...makeDeck(deckId, userId),
+  deckCard: cardIds.map((cardId, index) => ({
+    id: index + 1,
+    deckId,
+    cardId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    card: makeCard(cardId),
+  })),
+});
+
+
+// ─── Repository unit tests ────────────────────────────────────────────────────
+
+describe("deckRepository — fonctions non couvertes", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "test-secret";
+  });
+
+  beforeEach(() => {
+    prismaMock.deck.create.mockReset();
+    prismaMock.deck.update.mockReset();
+    prismaMock.deck.delete.mockReset();
+    prismaMock.deckCard.createMany.mockReset();
+    prismaMock.deckCard.deleteMany.mockReset();
+  });
+
+  // lines 5-10 — createDeck
+  it("createDeck → appelle prisma.deck.create avec userId et name", async () => {
+    const expected = makeDeck(1, 42);
+    prismaMock.deck.create.mockResolvedValue(expected);
+
+    const result = await deckRepository.createDeck(42, "Test Deck");
+
+    expect(prismaMock.deck.create).toHaveBeenCalledWith({
+      data: { userId: 42, name: "Test Deck" },
+    });
+    expect(result).toEqual(expected);
+  });
+
+  // lines 12-16 — addDeckCards
+  it("addDeckCards → appelle prisma.deckCard.createMany avec les bons deckCard", async () => {
+    prismaMock.deckCard.createMany.mockResolvedValue({ count: 3 });
+
+    const result = await deckRepository.addDeckCards(5, [10, 20, 30]);
+
+    expect(prismaMock.deckCard.createMany).toHaveBeenCalledWith({
+      data: [
+        { deckId: 5, cardId: 10 },
+        { deckId: 5, cardId: 20 },
+        { deckId: 5, cardId: 30 },
+      ],
+    });
+    expect(result).toEqual({ count: 3 });
+  });
+
+  // line 17 — deleteDeckCards
+  it("deleteDeckCards → appelle prisma.deckCard.deleteMany avec le bon deckId", async () => {
+    prismaMock.deckCard.deleteMany.mockResolvedValue({ count: 10 });
+
+    const result = await deckRepository.deleteDeckCards(5);
+
+    expect(prismaMock.deckCard.deleteMany).toHaveBeenCalledWith({
+      where: { deckId: 5 },
+    });
+    expect(result).toEqual({ count: 10 });
+  });
+
+  // lines 40-43 — updateDeckName
+  it("updateDeckName → appelle prisma.deck.update avec le bon id et name", async () => {
+    const updated = makeDeck(7, 1);
+    prismaMock.deck.update.mockResolvedValue(updated);
+
+    const result = await deckRepository.updateDeckName(7, "Nouveau Nom");
+
+    expect(prismaMock.deck.update).toHaveBeenCalledWith({
+      where: { id: 7 },
+      data: { name: "Nouveau Nom" },
+    });
+    expect(result).toEqual(updated);
+  });
+
+  // lines 45-47 — deleteDeck
+  it("deleteDeck → appelle prisma.deck.delete avec le bon id", async () => {
+    const deleted = makeDeck(7, 1);
+    prismaMock.deck.delete.mockResolvedValue(deleted);
+
+    const result = await deckRepository.deleteDeck(7);
+
+    expect(prismaMock.deck.delete).toHaveBeenCalledWith({ where: { id: 7 } });
+    expect(result).toEqual(deleted);
+  });
+});
+
+// ─── Controller — req.body fallback (lines 8 & 46) ───────────────────────────
+
+describe("deckController — req.body absent (fallback ?? {})", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "test-secret";
+  });
+
+  beforeEach(() => {
+    prismaMock.$transaction.mockReset();
+    prismaMock.deck.findFirst.mockReset();
+    prismaMock.card.findMany.mockReset();
+  });
+
+  /**
+   * POST /api/decks sans body → le contrôleur fait `req.body ?? {}`
+   * puis le service valide et renvoie 400 (name manquant).
+   * L'important est que la ligne 8 du controller soit exécutée sans crash.
+   */
+  it("POST /api/decks sans body → 400 (name manquant, line 8 couverte)", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+
+    // Envoyer une requête sans .send() pour que req.body soit vide/undefined
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+  });
+
+  /**
+   * PATCH /api/decks/:id sans body → le contrôleur fait `req.body ?? {}`
+   * puis le service valide et renvoie 400 (aucune donnée).
+   * L'important est que la ligne 46 du controller soit exécutée.
+   */
+  it("PATCH /api/decks/:id sans body → 400 (aucune donnée, line 46 couverte)", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .set("Content-Type", "application/json");
+
+    expect(res.status).toBe(400);
+  });
+});

--- a/tests/deck.test.ts
+++ b/tests/deck.test.ts
@@ -71,16 +71,14 @@ describe("API Decks (CRUD)", () => {
     prismaMock.card.findMany.mockReset();
   });
 
-  // ─── POST /api/decks ──────────────────────────────────────────────────────
-
-  it("POST /api/decks → 401 si pas de token", async () => {
+  it("POST /api/decks : 401 si pas de token", async () => {
     const res = await request(app)
       .post("/api/decks")
       .send({ name: "Deck", cards: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
     expect(res.status).toBe(401);
   });
 
-  it("POST /api/decks → 400 si nom manquant", async () => {
+  it("POST /api/decks : 400 si nom manquant", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .post("/api/decks")
@@ -89,7 +87,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/decks → 400 si cards n'est pas un tableau", async () => {
+  it("POST /api/decks : 400 si cards n'est pas un tableau", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .post("/api/decks")
@@ -98,7 +96,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/decks → 400 si pas exactement 10 cartes", async () => {
+  it("POST /api/decks : 400 si pas exactement 10 cartes", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .post("/api/decks")
@@ -107,7 +105,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/decks → 400 si cards contient des IDs non-entiers", async () => {
+  it("POST /api/decks : 400 si cards contient des IDs non-entiers", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .post("/api/decks")
@@ -116,7 +114,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/decks → 400 si cards contient des doublons", async () => {
+  it("POST /api/decks : 400 si cards contient des doublons", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .post("/api/decks")
@@ -125,7 +123,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/decks → 400 si IDs de cartes inexistants en DB", async () => {
+  it("POST /api/decks : 400 si IDs de cartes inexistants en DB", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.card.findMany.mockResolvedValue(
       Array.from({ length: 9 }, (_, i) => makeCard(i + 1)),
@@ -137,7 +135,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("POST /api/decks → 201 si 10 cartes valides", async () => {
+  it("POST /api/decks : 201 si 10 cartes valides", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     prismaMock.card.findMany.mockResolvedValue(ids.map(makeCard));
@@ -154,7 +152,7 @@ describe("API Decks (CRUD)", () => {
     expect(prismaMock.deckCard.createMany).toHaveBeenCalledTimes(1);
   });
 
-  it("POST /api/decks → 500 si erreur serveur", async () => {
+  it("POST /api/decks : 500 si erreur serveur", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
     prismaMock.card.findMany.mockResolvedValue(ids.map(makeCard));
@@ -166,14 +164,12 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(500);
   });
 
-  // ─── GET /api/decks/mine ──────────────────────────────────────────────────
-
-  it("GET /api/decks/mine → 401 si pas de token", async () => {
+  it("GET /api/decks/mine : 401 si pas de token", async () => {
     const res = await request(app).get("/api/decks/mine");
     expect(res.status).toBe(401);
   });
 
-  it("GET /api/decks/mine → 200 et liste vide si aucun deck", async () => {
+  it("GET /api/decks/mine : 200 et liste vide si aucun deck", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findMany.mockResolvedValue([]);
     const res = await request(app)
@@ -183,7 +179,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.body).toEqual([]);
   });
 
-  it("GET /api/decks/mine → 200 et retourne les decks du user connecte", async () => {
+  it("GET /api/decks/mine : 200 et retourne les decks du user connecte", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findMany.mockResolvedValue([
       makeDeckWithCards(1, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -195,7 +191,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.body).toHaveLength(1);
   });
 
-  it("GET /api/decks/mine → 500 si erreur serveur", async () => {
+  it("GET /api/decks/mine : 500 si erreur serveur", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findMany.mockRejectedValue(new Error("DB down"));
     const res = await request(app)
@@ -204,14 +200,12 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(500);
   });
 
-  // ─── GET /api/decks/:id ───────────────────────────────────────────────────
-
-  it("GET /api/decks/:id → 401 si pas de token", async () => {
+  it("GET /api/decks/:id : 401 si pas de token", async () => {
     const res = await request(app).get("/api/decks/10");
     expect(res.status).toBe(401);
   });
 
-  it("GET /api/decks/:id → 404 si id non numerique", async () => {
+  it("GET /api/decks/:id : 404 si id non numerique", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .get("/api/decks/abc")
@@ -219,7 +213,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("GET /api/decks/:id → 404 si deck inexistant", async () => {
+  it("GET /api/decks/:id : 404 si deck inexistant", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(null);
     const res = await request(app)
@@ -228,7 +222,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("GET /api/decks/:id → 200 si deck existe et appartient au user", async () => {
+  it("GET /api/decks/:id : 200 si deck existe et appartient au user", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -239,7 +233,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(200);
   });
 
-  it("GET /api/decks/:id → 500 si erreur serveur", async () => {
+  it("GET /api/decks/:id : 500 si erreur serveur", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockRejectedValue(new Error("DB down"));
     const res = await request(app)
@@ -248,14 +242,12 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(500);
   });
 
-  // ─── PATCH /api/decks/:id ─────────────────────────────────────────────────
-
-  it("PATCH /api/decks/:id → 401 si pas de token", async () => {
+  it("PATCH /api/decks/:id : 401 si pas de token", async () => {
     const res = await request(app).patch("/api/decks/10").send({ name: "x" });
     expect(res.status).toBe(401);
   });
 
-  it("PATCH /api/decks/:id → 404 si id non numerique", async () => {
+  it("PATCH /api/decks/:id : 404 si id non numerique", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .patch("/api/decks/abc")
@@ -264,7 +256,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("PATCH /api/decks/:id → 404 si deck inexistant", async () => {
+  it("PATCH /api/decks/:id : 404 si deck inexistant", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(null);
     const res = await request(app)
@@ -274,7 +266,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("PATCH /api/decks/:id → 400 si aucune donnee envoyee", async () => {
+  it("PATCH /api/decks/:id : 400 si aucune donnee envoyee", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -286,7 +278,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("PATCH /api/decks/:id → 400 si nom est une chaine vide", async () => {
+  it("PATCH /api/decks/:id : 400 si nom est une chaine vide", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -298,7 +290,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("PATCH /api/decks/:id → 400 si cartes fournies mais pas 10", async () => {
+  it("PATCH /api/decks/:id : 400 si cartes fournies mais pas 10", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -310,7 +302,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("PATCH /api/decks/:id → 400 si cartes inexistantes en DB", async () => {
+  it("PATCH /api/decks/:id : 400 si cartes inexistantes en DB", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -325,7 +317,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(400);
   });
 
-  it("PATCH /api/decks/:id → 200 si update du nom seulement", async () => {
+  it("PATCH /api/decks/:id : 200 si update du nom seulement", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -343,7 +335,7 @@ describe("API Decks (CRUD)", () => {
     expect(prismaMock.deck.update).toHaveBeenCalledTimes(1);
   });
 
-  it("PATCH /api/decks/:id → 200 si update des cartes (remplacement complet)", async () => {
+  it("PATCH /api/decks/:id : 200 si update des cartes", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const newIds = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
     prismaMock.deck.findFirst.mockResolvedValue(
@@ -363,7 +355,7 @@ describe("API Decks (CRUD)", () => {
     expect(prismaMock.deckCard.createMany).toHaveBeenCalledTimes(1);
   });
 
-  it("PATCH /api/decks/:id → 500 si erreur serveur", async () => {
+  it("PATCH /api/decks/:id : 500 si erreur serveur", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockRejectedValue(new Error("DB down"));
     const res = await request(app)
@@ -373,14 +365,12 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(500);
   });
 
-  // ─── DELETE /api/decks/:id ────────────────────────────────────────────────
-
-  it("DELETE /api/decks/:id → 401 si pas de token", async () => {
+  it("DELETE /api/decks/:id : 401 si pas de token", async () => {
     const res = await request(app).delete("/api/decks/10");
     expect(res.status).toBe(401);
   });
 
-  it("DELETE /api/decks/:id → 404 si id non numerique", async () => {
+  it("DELETE /api/decks/:id : 404 si id non numerique", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     const res = await request(app)
       .delete("/api/decks/abc")
@@ -388,7 +378,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("DELETE /api/decks/:id → 404 si deck inexistant", async () => {
+  it("DELETE /api/decks/:id : 404 si deck inexistant", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(null);
     const res = await request(app)
@@ -397,7 +387,7 @@ describe("API Decks (CRUD)", () => {
     expect(res.status).toBe(404);
   });
 
-  it("DELETE /api/decks/:id → 204 et suppression des DeckCards en cascade", async () => {
+  it("DELETE /api/decks/:id : 204 et suppression des DeckCards en cascade", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockResolvedValue(
       makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
@@ -414,7 +404,7 @@ describe("API Decks (CRUD)", () => {
     expect(prismaMock.deck.delete).toHaveBeenCalledTimes(1);
   });
 
-  it("DELETE /api/decks/:id → 500 si erreur serveur", async () => {
+  it("DELETE /api/decks/:id : 500 si erreur serveur", async () => {
     const token = makeToken({ userId: 1, email: "red@tcg.com" });
     prismaMock.deck.findFirst.mockRejectedValue(new Error("DB down"));
     const res = await request(app)

--- a/tests/deck.test.ts
+++ b/tests/deck.test.ts
@@ -1,0 +1,425 @@
+import { describe, it, expect, beforeAll, beforeEach } from "vitest";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { app } from "../src/index";
+import { prismaMock } from "./vitest.setup";
+import { PokemonType } from "../src/generated/prisma/client";
+import type { Prisma } from "../src/generated/prisma/client";
+
+type TokenPayload = { userId: number; email: string };
+
+const makeToken = (payload: TokenPayload) => {
+  const secret = process.env.JWT_SECRET;
+  if (!secret) throw new Error("JWT_SECRET manquant dans les tests");
+  return jwt.sign(payload, secret, { expiresIn: "7d" });
+};
+
+const makeCard = (id: number) => ({
+  id,
+  name: `Card ${id}`,
+  pokedexNumber: id,
+  hp: 10,
+  attack: 10,
+  type: PokemonType.Grass,
+  imgUrl: "",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const makeDeck = (deckId: number, userId: number) => ({
+  id: deckId,
+  name: "My Starter Deck",
+  userId,
+  createdAt: new Date(),
+  updatedAt: new Date(),
+});
+
+const makeDeckWithCards = (deckId: number, userId: number, cardIds: number[]) => ({
+  ...makeDeck(deckId, userId),
+  deckCard: cardIds.map((cardId, index) => ({
+    id: index + 1,
+    deckId,
+    cardId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    card: makeCard(cardId),
+  })),
+});
+
+const mockTransaction = () => {
+  prismaMock.$transaction.mockImplementation(
+    (fn: (tx: Prisma.TransactionClient) => Promise<unknown>) =>
+      fn(prismaMock as unknown as Prisma.TransactionClient),
+  );
+};
+
+describe("API Decks (CRUD)", () => {
+  beforeAll(() => {
+    process.env.JWT_SECRET = "test-secret";
+  });
+
+  beforeEach(() => {
+    prismaMock.$transaction.mockReset();
+    prismaMock.deck.findFirst.mockReset();
+    prismaMock.deck.findMany.mockReset();
+    prismaMock.deck.create.mockReset();
+    prismaMock.deck.update.mockReset();
+    prismaMock.deck.delete.mockReset();
+    prismaMock.deck.findUnique.mockReset();
+    prismaMock.deckCard.createMany.mockReset();
+    prismaMock.deckCard.deleteMany.mockReset();
+    prismaMock.card.findMany.mockReset();
+  });
+
+  // ─── POST /api/decks ──────────────────────────────────────────────────────
+
+  it("POST /api/decks → 401 si pas de token", async () => {
+    const res = await request(app)
+      .post("/api/decks")
+      .send({ name: "Deck", cards: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /api/decks → 400 si nom manquant", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ cards: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10] });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/decks → 400 si cards n'est pas un tableau", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Deck", cards: "pas-un-tableau" });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/decks → 400 si pas exactement 10 cartes", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Deck", cards: [1, 2, 3] });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/decks → 400 si cards contient des IDs non-entiers", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Deck", cards: [1, 2, 3, 4, 5, 6, 7, 8, 9, "dix"] });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/decks → 400 si cards contient des doublons", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Deck", cards: [1, 1, 2, 3, 4, 5, 6, 7, 8, 9] });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/decks → 400 si IDs de cartes inexistants en DB", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.card.findMany.mockResolvedValue(
+      Array.from({ length: 9 }, (_, i) => makeCard(i + 1)),
+    );
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Deck", cards: [1, 2, 3, 4, 5, 6, 7, 8, 9, 999] });
+    expect(res.status).toBe(400);
+  });
+
+  it("POST /api/decks → 201 si 10 cartes valides", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    prismaMock.card.findMany.mockResolvedValue(ids.map(makeCard));
+    mockTransaction();
+    prismaMock.deck.create.mockResolvedValue(makeDeck(10, 1));
+    prismaMock.deckCard.createMany.mockResolvedValue({ count: 10 });
+    prismaMock.deck.findUnique.mockResolvedValue(makeDeckWithCards(10, 1, ids));
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "My Starter Deck", cards: ids });
+    expect(res.status).toBe(201);
+    expect(prismaMock.deck.create).toHaveBeenCalledTimes(1);
+    expect(prismaMock.deckCard.createMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("POST /api/decks → 500 si erreur serveur", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const ids = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+    prismaMock.card.findMany.mockResolvedValue(ids.map(makeCard));
+    prismaMock.$transaction.mockRejectedValue(new Error("DB down"));
+    const res = await request(app)
+      .post("/api/decks")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Deck", cards: ids });
+    expect(res.status).toBe(500);
+  });
+
+  // ─── GET /api/decks/mine ──────────────────────────────────────────────────
+
+  it("GET /api/decks/mine → 401 si pas de token", async () => {
+    const res = await request(app).get("/api/decks/mine");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/decks/mine → 200 et liste vide si aucun deck", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findMany.mockResolvedValue([]);
+    const res = await request(app)
+      .get("/api/decks/mine")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual([]);
+  });
+
+  it("GET /api/decks/mine → 200 et retourne les decks du user connecte", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findMany.mockResolvedValue([
+      makeDeckWithCards(1, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    ]);
+    const res = await request(app)
+      .get("/api/decks/mine")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveLength(1);
+  });
+
+  it("GET /api/decks/mine → 500 si erreur serveur", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findMany.mockRejectedValue(new Error("DB down"));
+    const res = await request(app)
+      .get("/api/decks/mine")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(500);
+  });
+
+  // ─── GET /api/decks/:id ───────────────────────────────────────────────────
+
+  it("GET /api/decks/:id → 401 si pas de token", async () => {
+    const res = await request(app).get("/api/decks/10");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /api/decks/:id → 404 si id non numerique", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .get("/api/decks/abc")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/decks/:id → 404 si deck inexistant", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(null);
+    const res = await request(app)
+      .get("/api/decks/999")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /api/decks/:id → 200 si deck existe et appartient au user", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    const res = await request(app)
+      .get("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it("GET /api/decks/:id → 500 si erreur serveur", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockRejectedValue(new Error("DB down"));
+    const res = await request(app)
+      .get("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(500);
+  });
+
+  // ─── PATCH /api/decks/:id ─────────────────────────────────────────────────
+
+  it("PATCH /api/decks/:id → 401 si pas de token", async () => {
+    const res = await request(app).patch("/api/decks/10").send({ name: "x" });
+    expect(res.status).toBe(401);
+  });
+
+  it("PATCH /api/decks/:id → 404 si id non numerique", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .patch("/api/decks/abc")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Updated" });
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /api/decks/:id → 404 si deck inexistant", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(null);
+    const res = await request(app)
+      .patch("/api/decks/999")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Updated" });
+    expect(res.status).toBe(404);
+  });
+
+  it("PATCH /api/decks/:id → 400 si aucune donnee envoyee", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({});
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/decks/:id → 400 si nom est une chaine vide", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "   " });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/decks/:id → 400 si cartes fournies mais pas 10", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ cards: [1, 2, 3] });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/decks/:id → 400 si cartes inexistantes en DB", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    prismaMock.card.findMany.mockResolvedValue(
+      Array.from({ length: 9 }, (_, i) => makeCard(i + 11)),
+    );
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ cards: [11, 12, 13, 14, 15, 16, 17, 18, 19, 999] });
+    expect(res.status).toBe(400);
+  });
+
+  it("PATCH /api/decks/:id → 200 si update du nom seulement", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    mockTransaction();
+    prismaMock.deck.update.mockResolvedValue(makeDeck(10, 1));
+    prismaMock.deck.findUnique.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Updated" });
+    expect(res.status).toBe(200);
+    expect(prismaMock.deck.update).toHaveBeenCalledTimes(1);
+  });
+
+  it("PATCH /api/decks/:id → 200 si update des cartes (remplacement complet)", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const newIds = [11, 12, 13, 14, 15, 16, 17, 18, 19, 20];
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    prismaMock.card.findMany.mockResolvedValue(newIds.map(makeCard));
+    mockTransaction();
+    prismaMock.deckCard.deleteMany.mockResolvedValue({ count: 10 });
+    prismaMock.deckCard.createMany.mockResolvedValue({ count: 10 });
+    prismaMock.deck.findUnique.mockResolvedValue(makeDeckWithCards(10, 1, newIds));
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ cards: newIds });
+    expect(res.status).toBe(200);
+    expect(prismaMock.deckCard.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.deckCard.createMany).toHaveBeenCalledTimes(1);
+  });
+
+  it("PATCH /api/decks/:id → 500 si erreur serveur", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockRejectedValue(new Error("DB down"));
+    const res = await request(app)
+      .patch("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`)
+      .send({ name: "Updated" });
+    expect(res.status).toBe(500);
+  });
+
+  // ─── DELETE /api/decks/:id ────────────────────────────────────────────────
+
+  it("DELETE /api/decks/:id → 401 si pas de token", async () => {
+    const res = await request(app).delete("/api/decks/10");
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /api/decks/:id → 404 si id non numerique", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    const res = await request(app)
+      .delete("/api/decks/abc")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE /api/decks/:id → 404 si deck inexistant", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(null);
+    const res = await request(app)
+      .delete("/api/decks/999")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(404);
+  });
+
+  it("DELETE /api/decks/:id → 204 et suppression des DeckCards en cascade", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockResolvedValue(
+      makeDeckWithCards(10, 1, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]),
+    );
+    mockTransaction();
+    prismaMock.deckCard.deleteMany.mockResolvedValue({ count: 10 });
+    prismaMock.deck.delete.mockResolvedValue(makeDeck(10, 1));
+    const res = await request(app)
+      .delete("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(204);
+    expect(res.text).toBe("");
+    expect(prismaMock.deckCard.deleteMany).toHaveBeenCalledTimes(1);
+    expect(prismaMock.deck.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it("DELETE /api/decks/:id → 500 si erreur serveur", async () => {
+    const token = makeToken({ userId: 1, email: "red@tcg.com" });
+    prismaMock.deck.findFirst.mockRejectedValue(new Error("DB down"));
+    const res = await request(app)
+      .delete("/api/decks/10")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/vitest.setup.ts
+++ b/tests/vitest.setup.ts
@@ -12,3 +12,5 @@ beforeEach(() => {
 })
 
 export const prismaMock = prisma as unknown as DeepMockProxy<PrismaClient>
+
+process.env.JWT_SECRET = "test-secret";

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "module": "commonjs",
     "lib": ["ES2022"],
     "outDir": "./dist",
-    "rootDir": "./src",
+    "rootDir": ".",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
@@ -22,6 +22,6 @@
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true
   },
-  "include": ["src/**/*"],
+  "include": ["src/**/*", "tests", "prisma"],
   "exclude": ["node_modules", "dist"]
 }


### PR DESCRIPTION
## Description

Ajout des tests unitaires

## Type de changement

<!-- Cochez les cases appropriées -->

- [ ] 🐛 Bug fix
- [ ] ✨ Nouvelle fonctionnalité
- [ ] 💥 Breaking change
- [ ] 📝 Documentation
- [ ] ♻️ Refactorisation
- [x] ♻️ Tests

## Checklist

- [x] Mon code respecte les guidelines du projet
- [x] J'ai testé mes modifications localement
- [x] J'ai ajouté des tests pour mes changements
- [x] La documentation a été mise à jour si nécessaire
- [x] Tous les tests passent (`npm test`)
- [x] Le linting passe (`npm run lint`)
- [x] J'ai suivi la convention Conventional Commits

## Tests effectués

Création des tests unitaires qui gèrent les endpoints d'authentification,  les endpoint de consultation des cartes, le CRUD complet des decks et l'authentification JWT avec 100% des tests réussis et de coverage.

Pour tester, executer run --coverage et avoir 100% 

## Issues liées

Closes #6 
